### PR TITLE
Update _index.md

### DIFF
--- a/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/cloud-providers/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/cloud-providers/_index.md
@@ -38,7 +38,7 @@ For details on enabling the vSphere cloud provider, refer to [this page.](./vsph
 
 ### Setting up a Custom Cloud Provider
 
-The `Custom` cloud provider is available if you want to configure any [Kubernetes cloud provider](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/).
+The `Custom` cloud provider is available if you want to configure any Kubernetes cloud provider.
 
 For the custom cloud provider option, you can refer to the [RKE docs]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/) on how to edit the yaml file for your specific cloud provider. There are specific cloud providers that have more detailed configuration :
 


### PR DESCRIPTION
Remove link to `docs/concept/cluster-administration/cloud-providers/` as it's no longer maintain since release-1.19
More context: https://github.com/kubernetes/website/pull/23517